### PR TITLE
HDF-119 - Introduce conditional showing of 'subheading' (also called 'label') on 'collapsible' function

### DIFF
--- a/src/collapsible.js
+++ b/src/collapsible.js
@@ -1,5 +1,17 @@
 import zenscroll from "zenscroll";
 
+function hideElement(el) {
+  el.setAttribute("hidden", "");
+  el.setAttribute("aria-hidden", "");
+  el.style.display = "none";
+}
+
+function showElement(el) {
+  el.removeAttribute("hidden");
+  el.removeAttribute("aria-hidden", "");
+  el.style.display = "block";
+}
+
 function collapsible(e) {
   const element = e.currentTarget;
   const expanded =
@@ -7,7 +19,7 @@ function collapsible(e) {
   // Toggle expanded value
   element.setAttribute("aria-expanded", String(!expanded));
 
-  // Toggle active modifier class
+  // Toggle active collapsible class on 'collapsible' button
   const elemClasses = element.classList;
   if (elemClasses.contains("b-collapsible__button--active")) {
     elemClasses.remove("b-collapsible__button--active");
@@ -19,6 +31,21 @@ function collapsible(e) {
     element.getAttribute("aria-controls")
   );
   toggleContent(content, expanded);
+
+  // --- Subheading handling ---
+
+  // The subheading element that renders as a 'p' tag, non-clickable
+  const subheadingEl = element.querySelectorAll("b-collapsible__meta-heading")[0];
+  // The subheading element that renders as a 'div', containing the nested collapsible markup
+  const subheadingElCollapsible = element.querySelectorAll(".b-collapsible__subheading-collapsible")[0];
+
+  if (expanded) {
+    hideElement(subheadingEl);
+    showElement(subheadingElCollapsible);
+  } else {
+    hideElement(subheadingElCollapsible);
+    showElement(subheadingEl);
+  }
 }
 
 function findWrapper(child) {

--- a/src/collapsible.js
+++ b/src/collapsible.js
@@ -2,7 +2,7 @@ import zenscroll from "zenscroll";
 
 function hideElement(el) {
   el.setAttribute("hidden", "");
-  el.setAttribute("aria-hidden", "");
+  el.setAttribute("aria-hidden", "true"); 
   el.style.display = "none";
 }
 

--- a/src/collapsible.js
+++ b/src/collapsible.js
@@ -2,13 +2,13 @@ import zenscroll from "zenscroll";
 
 function hideElement(el) {
   el.setAttribute("hidden", "");
-  el.setAttribute("aria-hidden", "true"); 
+  el.setAttribute("aria-hidden", "true");
   el.style.display = "none";
 }
 
 function showElement(el) {
   el.removeAttribute("hidden");
-  el.removeAttribute("aria-hidden", "");
+  el.removeAttribute("aria-hidden");
   el.style.display = "block";
 }
 
@@ -72,10 +72,10 @@ function collapseFromUrl() {
 function toggleContent(content, expanded) {
   if (expanded) {
     content.setAttribute("hidden", "");
-    content.setAttribute("aria-hidden", "");
+    content.setAttribute("aria-hidden", "true");
   } else {
     content.removeAttribute("hidden");
-    content.removeAttribute("aria-hidden", "");
+    content.removeAttribute("aria-hidden");
   }
   // Animates the scroll to the element, making sure the top of the expanding area is in the window view
   zenscroll.intoView(findWrapper(content), 300);


### PR DESCRIPTION
For this PR to take effect the backend should render both markup variations that are now wrongly conditionally loaded in the React component called `Collapsible`. They are:

```html
<p className="b-collapsible__meta-heading">Anbefaling</p>
```

and

```html
<div class="b-collapsible__subheading-collapsible l-mt-1">
  <div class="b-collapsible b-collapsible--subtle b-collapsible--small">
    <button class="b-collapsible__button b-collapsible__button--subtle b-collapsible__button--small" aria-expanded="false" aria-controls="9d835af0-92e4-4265-876a-a9061e63bed1">
      <div class="b-collapsible__heading normal">Anbefaling</div>
    </button>
    <div id="9d835af0-92e4-4265-876a-a9061e63bed1" aria-hidden hidden class="b-collapsible__content b-collapsible__content--small">
      <p>Innhold som vises når en klikker på 'Anbefaling'</p>
    </div>
  </div>
</div>
```

The updated javascript will hide one and show the other, according to the `expanded/collapsed` state of the parent element.